### PR TITLE
fix: honor HOME for Forge config path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,10 @@ type Config struct {
 }
 
 func Path() string {
-	home, _ := os.UserHomeDir()
+	home := os.Getenv("HOME")
+	if home == "" {
+		home, _ = os.UserHomeDir()
+	}
 	return filepath.Join(home, ".forge", "config")
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPath_UsesHOMEWhenSet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := Path()
+	want := filepath.Join(home, ".forge", "config")
+	if got != want {
+		t.Fatalf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestLoad_UsesHOMEWhenSet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(home, ".forge", "config")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("FORGE_PROVIDER=openai\nFORGE_API_KEY=test-key\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Provider != "openai" {
+		t.Fatalf("Provider = %q, want openai", cfg.Provider)
+	}
+	if cfg.APIKey != "test-key" {
+		t.Fatalf("APIKey = %q, want test-key", cfg.APIKey)
+	}
+}


### PR DESCRIPTION
## Summary
- make config path resolution honor `HOME` before falling back to the user profile
- add tests covering config path/load behavior under temp HOME
- keep the change isolated to the CI-facing config lookup path

## Validation
- go test ./internal/config ./cmd -run 'TestRunDistill_UnconfiguredProviderSkipsAndKeepsQueue|TestFindTransientForgeReference_WindowsStylePath|TestBinary_Doctor_ReportsTransientIntegrationReference' -count=1
- go test ./... -count=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config directory resolution to properly respect HOME environment variable settings.

* **Tests**
  * Added test coverage for config path and loading functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->