### PR TITLE
fix: resolve Windows CI test-windows failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         run: ls -lh forge-*
 
   test-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,11 @@ jobs:
           go test ./... -v -count=1 -timeout 240s 2>&1 | Tee-Object -Variable captured
           $ec = $LASTEXITCODE
           # On Windows, go test exits 1 when it cannot delete the test binary after a
-          # successful run (OS file lock). Propagate failure only for real test failures
-          # (lines starting with "FAIL "). Must explicit exit 0 so pwsh doesn't
-          # propagate go test's $LASTEXITCODE as the step exit code.
-          if (($ec -ne 0) -and ($captured -match "(?m)^FAIL\s")) { exit 1 }
+          # successful run (OS file lock) or when orphaned daemon processes hold files.
+          # Only propagate failure for real test failures — lines like "FAIL\tpkg".
+          # The bare "FAIL" at the end of go test output (no package) is not a real
+          # test failure. We match "FAIL\t" to require a package name after FAIL.
+          if (($ec -ne 0) -and ($captured -match "(?m)^FAIL\t")) { exit 1 }
           exit 0
 
   integration-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,15 +83,24 @@ jobs:
       - name: Unit tests
         shell: pwsh
         run: |
-          go test ./... -v -count=1 -timeout 240s 2>&1 | Tee-Object -Variable captured
-          $ec = $LASTEXITCODE
-          # On Windows, go test exits 1 when it cannot delete the test binary after a
-          # successful run (OS file lock) or when orphaned daemon processes hold files.
-          # Only propagate failure for real test failures — lines like "FAIL\tpkg".
-          # The bare "FAIL" at the end of go test output (no package) is not a real
-          # test failure. We match "FAIL\t" to require a package name after FAIL.
-          if (($ec -ne 0) -and ($captured -match "(?m)^FAIL\t")) { exit 1 }
-          exit 0
+          # Write output to a temp file instead of a pipe (Tee-Object). Using a pipe
+          # causes daemon grandchild processes (spawned by integration tests via
+          # "forge start") to inherit the pipe's write handle. Those daemons outlive
+          # "go test" and keep the pipe open, blocking PowerShell indefinitely.
+          # A temp file has no such "all-writers-must-close" semantics.
+          $tmpLog = [System.IO.Path]::GetTempFileName()
+          try {
+            go test ./... -v -count=1 -timeout 240s > $tmpLog 2>&1
+            $ec = $LASTEXITCODE
+            $captured = Get-Content $tmpLog -Raw
+            Write-Host $captured
+            # Only propagate failure for real test failures — lines like "FAIL\tpkg".
+            # The bare "FAIL" at the end of go test output is not a real test failure.
+            if (($ec -ne 0) -and ($captured -match "(?m)^FAIL\t")) { exit 1 }
+            exit 0
+          } finally {
+            Remove-Item $tmpLog -ErrorAction SilentlyContinue
+          }
 
   integration-windows:
     runs-on: windows-latest

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -39,6 +39,20 @@ func killProcessTree(pid int) {
 	}
 }
 
+// waitOrTimeout calls cmd.Wait with a bounded timeout so test cleanup never
+// hangs if process-tree kill fails to terminate the daemon.
+func waitOrTimeout(cmd *exec.Cmd, timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+}
+
 // shortHome creates a short temp dir to avoid Unix socket path length limits
 // (104 bytes on macOS). On Unix we use /tmp; on Windows os.TempDir() is fine
 // because IPC uses TCP (no socket path length constraint).
@@ -156,7 +170,7 @@ func startTestDaemonEnv(t *testing.T, home string, extraEnv []string) *exec.Cmd 
 	}
 	t.Cleanup(func() {
 		killProcessTree(cmd.Process.Pid)
-		cmd.Wait()
+		waitOrTimeout(cmd, 5*time.Second)
 		// Only log daemon stderr on failure to avoid noise in passing tests.
 		if t.Failed() {
 			if s := errBuf.String(); s != "" {
@@ -398,8 +412,8 @@ func TestBinary_DoubleStart(t *testing.T) {
 
 	// First start
 	runForge(t, home, "start")
-	waitForFile(t, addrFile, 3*time.Second)
 	t.Cleanup(func() { runForge(t, home, "stop") })
+	waitForFile(t, addrFile, 3*time.Second)
 
 	// Second start should report already running
 	stdout, _, code := runForge(t, home, "start")
@@ -554,8 +568,8 @@ func TestBinary_RestartCycle(t *testing.T) {
 
 	// Start again — should work even with potentially orphaned daemon from first start
 	runForge(t, home, "start")
-	waitForFile(t, addrFile, 3*time.Second)
 	t.Cleanup(func() { runForge(t, home, "stop") })
+	waitForFile(t, addrFile, 3*time.Second)
 }
 
 // KNOWN GOTCHA: forge stop removes the addr file but does not send SIGTERM to the
@@ -1676,7 +1690,7 @@ func TestBinary_MCPSelfHealing(t *testing.T) {
 	defer func() {
 		_ = stdin.Close()
 		killProcessTree(cmd.Process.Pid)
-		_ = cmd.Wait()
+		waitOrTimeout(cmd, 5*time.Second)
 		runForge(t, home, "stop")
 	}()
 

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -26,6 +26,19 @@ import (
 // forgeBin is the path to the compiled test binary, set by TestMain.
 var forgeBin string
 
+// killProcessTree kills a process and all its children. On Windows this uses
+// taskkill /T /F to kill the entire tree; on Unix it kills the process directly
+// (daemon runs in its own session via Setsid so children are not orphaned).
+func killProcessTree(pid int) {
+	if runtime.GOOS == "windows" {
+		exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run()
+		return
+	}
+	if proc, err := os.FindProcess(pid); err == nil {
+		proc.Kill()
+	}
+}
+
 // shortHome creates a short temp dir to avoid Unix socket path length limits
 // (104 bytes on macOS). On Unix we use /tmp; on Windows os.TempDir() is fine
 // because IPC uses TCP (no socket path length constraint).
@@ -142,7 +155,7 @@ func startTestDaemonEnv(t *testing.T, home string, extraEnv []string) *exec.Cmd 
 		t.Fatalf("start daemon: %v", err)
 	}
 	t.Cleanup(func() {
-		cmd.Process.Kill()
+		killProcessTree(cmd.Process.Pid)
 		cmd.Wait()
 		// Only log daemon stderr on failure to avoid noise in passing tests.
 		if t.Failed() {
@@ -386,6 +399,7 @@ func TestBinary_DoubleStart(t *testing.T) {
 	// First start
 	runForge(t, home, "start")
 	waitForFile(t, addrFile, 3*time.Second)
+	t.Cleanup(func() { runForge(t, home, "stop") })
 
 	// Second start should report already running
 	stdout, _, code := runForge(t, home, "start")
@@ -541,12 +555,16 @@ func TestBinary_RestartCycle(t *testing.T) {
 	// Start again — should work even with potentially orphaned daemon from first start
 	runForge(t, home, "start")
 	waitForFile(t, addrFile, 3*time.Second)
+	t.Cleanup(func() { runForge(t, home, "stop") })
 }
 
 // KNOWN GOTCHA: forge stop removes the addr file but does not send SIGTERM to the
 // daemon process. The daemon continues running, consuming the socket and database.
 // A subsequent forge start spawns a second daemon — two daemons on different sockets.
 func TestBinary_StopOrphan_Gotcha(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("syscall.Signal(0) liveness check not supported on Windows")
+	}
 	home := shortHome(t)
 
 	// Start daemon directly so we have its PID
@@ -583,6 +601,7 @@ func TestBinary_StaleAddr_Gotcha(t *testing.T) {
 	}
 
 	stdout, _, code := runForge(t, home, "start")
+	t.Cleanup(func() { runForge(t, home, "stop") })
 	if code != 0 {
 		t.Errorf("forge start with stale addr: expected exit 0, got %d", code)
 	}
@@ -1656,7 +1675,7 @@ func TestBinary_MCPSelfHealing(t *testing.T) {
 	
 	defer func() {
 		_ = stdin.Close()
-		_ = cmd.Process.Kill()
+		killProcessTree(cmd.Process.Pid)
 		_ = cmd.Wait()
 		runForge(t, home, "stop")
 	}()

--- a/cmd/kill_windows.go
+++ b/cmd/kill_windows.go
@@ -5,34 +5,34 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"time"
 )
 
-// killProcess terminates the given PID immediately (Windows has no SIGTERM).
+// killProcess terminates the given PID and its entire process tree on Windows.
+// Uses taskkill /T /F to kill child processes (e.g. daemon grandchildren
+// spawned by forge start) that os.Process.Kill would leave orphaned.
 func killProcess(pid int) error {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("find process %d: %w", pid, err)
+	// taskkill /T /F /PID kills the process tree. This is critical because
+	// forge start spawns a detached daemon grandchild — Process.Kill only
+	// kills the direct process, leaving the grandchild orphaned.
+	cmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
+	if err := cmd.Run(); err != nil {
+		// taskkill fails if process already exited — fall back to direct kill.
+		proc, findErr := os.FindProcess(pid)
+		if findErr != nil {
+			return nil
+		}
+		_ = proc.Kill()
 	}
 
-	// Try SIGKILL equivalent on Windows (will terminate immediately)
-	if err := proc.Kill(); err != nil {
-		return fmt.Errorf("kill process %d: %w", pid, err)
-	}
-
-	// Wait up to 3 seconds for process to exit
+	// Wait up to 3 seconds for process to fully exit.
 	for i := 0; i < 30; i++ {
-		if _, err := os.FindProcess(pid); err != nil {
-			return nil // Process is gone
+		if _, err := processIdentity(pid); err != nil {
+			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-
-	// Force kill - try to find the process again
-	proc2, err := os.FindProcess(pid)
-	if err != nil {
-		return nil // Process already gone
-	}
-	proc2.Kill()
-	return nil
+	return fmt.Errorf("process %d did not exit within 3s", pid)
 }

--- a/cmd/kill_windows.go
+++ b/cmd/kill_windows.go
@@ -13,13 +13,19 @@ import (
 // killProcess terminates the given PID and its entire process tree on Windows.
 // Uses taskkill /T /F to kill child processes (e.g. daemon grandchildren
 // spawned by forge start) that os.Process.Kill would leave orphaned.
+// Validates PID identity before killing to avoid terminating an unrelated
+// process tree if the PID was reused after a daemon crash.
 func killProcess(pid int) error {
-	// taskkill /T /F /PID kills the process tree. This is critical because
-	// forge start spawns a detached daemon grandchild — Process.Kill only
-	// kills the direct process, leaving the grandchild orphaned.
+	identity, err := processIdentity(pid)
+	if err != nil {
+		return nil // process already gone
+	}
+	if !isForgeProcessIdentity(identity) {
+		return nil // PID reused by a non-Forge process — treat as stale
+	}
+
 	cmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
 	if err := cmd.Run(); err != nil {
-		// taskkill fails if process already exited — fall back to direct kill.
 		proc, findErr := os.FindProcess(pid)
 		if findErr != nil {
 			return nil
@@ -27,7 +33,6 @@ func killProcess(pid int) error {
 		_ = proc.Kill()
 	}
 
-	// Wait up to 3 seconds for process to fully exit.
 	for i := 0; i < 30; i++ {
 		if _, err := processIdentity(pid); err != nil {
 			return nil

--- a/cmd/kill_windows.go
+++ b/cmd/kill_windows.go
@@ -26,16 +26,24 @@ func killProcess(pid int) error {
 
 	cmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
 	if err := cmd.Run(); err != nil {
+		// Re-check identity: process may have exited and PID been reused since the
+		// initial check above. Only fall back to proc.Kill if it's still our daemon.
+		if id2, idErr := processIdentity(pid); idErr != nil || !isForgeProcessIdentity(id2) {
+			return nil
+		}
 		proc, findErr := os.FindProcess(pid)
 		if findErr != nil {
 			return nil
 		}
-		_ = proc.Kill()
+		if killErr := proc.Kill(); killErr != nil {
+			return fmt.Errorf("taskkill failed: %w; fallback kill failed: %v", err, killErr)
+		}
 	}
 
 	for i := 0; i < 30; i++ {
-		if _, err := processIdentity(pid); err != nil {
-			return nil
+		id, err := processIdentity(pid)
+		if err != nil || !isForgeProcessIdentity(id) {
+			return nil // process gone or PID reused by something else
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/cmd/start_windows.go
+++ b/cmd/start_windows.go
@@ -29,8 +29,9 @@ const (
 func startBackground(cmd *exec.Cmd) error {
 	const base = detachedProcess | syscall.CREATE_NEW_PROCESS_GROUP | createNoWindow
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: base | createBreakawayFromJob,
-		HideWindow:    true,
+		CreationFlags:    base | createBreakawayFromJob,
+		HideWindow:       true,
+		NoInheritHandles: true,
 	}
 	if err := cmd.Start(); err == nil {
 		return nil
@@ -43,8 +44,9 @@ func startBackground(cmd *exec.Cmd) error {
 	retry.Env = cmd.Env
 	retry.Dir = cmd.Dir
 	retry.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: base,
-		HideWindow:    true,
+		CreationFlags:    base,
+		HideWindow:       true,
+		NoInheritHandles: true,
 	}
 	return retry.Start()
 }


### PR DESCRIPTION
## Summary

Fixes the persistent `test-windows` CI job failures that have been occurring since run #131. The root cause was orphaned `forge` daemon processes on Windows that held file locks, causing `go test` to exit non-zero.

Three fixes:

- **`cmd/kill_windows.go`**: Use `taskkill /T /F /PID` to kill the entire process tree instead of `os.Process.Kill()`, which only kills the direct process and leaves daemon grandchildren orphaned
- **`cmd/integration_test.go`**: Add `killProcessTree()` helper for test cleanup, apply it to `startTestDaemonEnv` and `MCPSelfHealing` cleanup, add missing `t.Cleanup(stop)` to 3 tests that were leaking daemons (`DoubleStart`, `RestartCycle`, `StaleAddr_Gotcha`), and skip `StopOrphan_Gotcha` on Windows (uses Unix-only `syscall.Signal(0)`)
- **`.github/workflows/ci.yml`**: Fix pwsh regex from `^FAIL\s` to `^FAIL\t` — the bare `FAIL\r\n` at end of `go test` output was matching `\s` (since `\r` is whitespace), falsely triggering failure even when all individual tests passed

## Test plan

- [ ] `test-windows` CI job passes (no orphaned forge processes in cleanup)
- [ ] `integration-windows` CI job continues to pass
- [ ] `test` (ubuntu) CI job continues to pass
- [ ] All cross-compile targets still build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwW6bjGowKjpnf3qBSduxY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwW6bjGowKjpnf3qBSduxY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CI test reliability by capturing full `go test` output and failing the step only when actual test failures are detected (instead of relying on piped output).
  * Strengthened integration-test shutdown by terminating entire process trees and adding bounded waits to prevent hangs when cleanup is slow or incomplete.
  * Improved Windows process start/stop behavior: safely handle stale or reused PIDs, and ensure background processes don’t inherit handles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->